### PR TITLE
Fix sort code typo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/lib/devengo/resources/shared/third_parties/identifiers/uk_scan.rb
+++ b/lib/devengo/resources/shared/third_parties/identifiers/uk_scan.rb
@@ -7,7 +7,7 @@ module Devengo
         module Identifiers
           class UkScan < Shared::Base
             map :type
-            map :short_code
+            map :sort_code
             map :account_number
           end
         end

--- a/spec/devengo/api/transactions_service_spec.rb
+++ b/spec/devengo/api/transactions_service_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
                     path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions"
 
     it "transactions with expected data" do
-      transaction1 = transactions.entries[0]
-      transaction2 = transactions.entries[1]
+      transaction1 = transactions.to_a[0]
+      transaction2 = transactions.to_a[1]
 
       expect(transaction1).to be_a Devengo::Resources::Transactions::Transaction
       expect(instance_methods_count(transaction1)).to eq 13

--- a/spec/devengo/api/transactions_service_spec.rb
+++ b/spec/devengo/api/transactions_service_spec.rb
@@ -63,14 +63,8 @@ RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
                     path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions"
 
     it "transactions with expected data" do
-      transactions_array = []
-
-      transactions.each do |tr|
-        transactions_array.push tr
-      end
-
-      transaction1 = transactions_array[0]
-      transaction2 = transactions_array[1]
+      transaction1 = transactions.entries[0]
+      transaction2 = transactions.entries[1]
 
       expect(transaction1).to be_a Devengo::Resources::Transactions::Transaction
       expect(instance_methods_count(transaction1)).to eq 13

--- a/spec/devengo/api/transactions_service_spec.rb
+++ b/spec/devengo/api/transactions_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
                     path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions/txn_3NuWZw8zSY2LNMoNXgVwaR",
                     resource: "transactions/find"
 
-    let!(:transaction) do # rubocop:disable RSpec/LetSetup
+    let!(:transaction) do
       transactions_service.find(account_id: "acc_fYpgX5Ytdxzexuf61lFmw", transaction_id: "txn_3NuWZw8zSY2LNMoNXgVwaR")
     end
 
@@ -69,73 +69,73 @@ RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
         transactions_array.push tr
       end
 
-      transaction_1 = transactions_array[0]
-      transaction_2 = transactions_array[1]
+      transaction1 = transactions_array[0]
+      transaction2 = transactions_array[1]
 
-      expect(transaction_1).to be_a Devengo::Resources::Transactions::Transaction
-      expect(instance_methods_count(transaction_1)).to eq 13
-      expect(transaction_1.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwaR"
-      expect(transaction_1.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
-      expect(transaction_1.description).to eq "Transaction description"
-      expect(transaction_1.operation_date).to eq "2022-01-01T12:00:10Z"
-      expect(transaction_1.created_at).to eq "2022-01-01T12:00:00Z"
-      expect(transaction_1.valued_at).to eq "2022-01-01T12:00:10Z"
-      expect(transaction_1.operation_type).to eq "deposit"
-      expect(transaction_1.credit_debit).to eq "debit"
-      expect(transaction_1.amount).to be_a Devengo::Resources::Shared::Money
-      expect(transaction_1.amount.cents).to eq 100
-      expect(transaction_1.amount.currency).to eq "EUR"
-      expect(transaction_1.balance).to be_a Devengo::Resources::Shared::Money
-      expect(transaction_1.balance.cents).to eq 10_000
-      expect(transaction_1.balance.currency).to eq "EUR"
-      expect(transaction_1.company_reference).to eq "123"
-      expect(transaction_1.entity).to be_a Devengo::Resources::Transactions::Entity
-      expect(transaction_1.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
-      expect(transaction_1.entity.type).to eq "payment"
-      expect(transaction_1.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
-      expect(transaction_1.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
-      expect(transaction_1.third_party.name).to eq "Company S.L."
-      expect(transaction_1.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
-      expect(transaction_1.third_party.account.identifiers.count).to eq 1
-      expect(transaction_1.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::Iban # rubocop:disable Layout/LineLength
-      expect(transaction_1.third_party.account.identifiers.first.type).to eq "iban"
-      expect(transaction_1.third_party.account.identifiers.first.iban).to eq "LT501243351241283711"
-      expect(transaction_1.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
-      expect(transaction_1.third_party.account.bank.name).to eq "Revolut Payments UAB"
-      expect(transaction_1.third_party.account.bank.bic).to eq "REVOLT21"
+      expect(transaction1).to be_a Devengo::Resources::Transactions::Transaction
+      expect(instance_methods_count(transaction1)).to eq 13
+      expect(transaction1.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwaR"
+      expect(transaction1.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
+      expect(transaction1.description).to eq "Transaction description"
+      expect(transaction1.operation_date).to eq "2022-01-01T12:00:10Z"
+      expect(transaction1.created_at).to eq "2022-01-01T12:00:00Z"
+      expect(transaction1.valued_at).to eq "2022-01-01T12:00:10Z"
+      expect(transaction1.operation_type).to eq "deposit"
+      expect(transaction1.credit_debit).to eq "debit"
+      expect(transaction1.amount).to be_a Devengo::Resources::Shared::Money
+      expect(transaction1.amount.cents).to eq 100
+      expect(transaction1.amount.currency).to eq "EUR"
+      expect(transaction1.balance).to be_a Devengo::Resources::Shared::Money
+      expect(transaction1.balance.cents).to eq 10_000
+      expect(transaction1.balance.currency).to eq "EUR"
+      expect(transaction1.company_reference).to eq "123"
+      expect(transaction1.entity).to be_a Devengo::Resources::Transactions::Entity
+      expect(transaction1.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction1.entity.type).to eq "payment"
+      expect(transaction1.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction1.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
+      expect(transaction1.third_party.name).to eq "Company S.L."
+      expect(transaction1.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
+      expect(transaction1.third_party.account.identifiers.count).to eq 1
+      expect(transaction1.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::Iban # rubocop:disable Layout/LineLength
+      expect(transaction1.third_party.account.identifiers.first.type).to eq "iban"
+      expect(transaction1.third_party.account.identifiers.first.iban).to eq "LT501243351241283711"
+      expect(transaction1.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
+      expect(transaction1.third_party.account.bank.name).to eq "Revolut Payments UAB"
+      expect(transaction1.third_party.account.bank.bic).to eq "REVOLT21"
 
-      expect(transaction_2).to be_a Devengo::Resources::Transactions::Transaction
-      expect(instance_methods_count(transaction_2)).to eq 13
-      expect(transaction_2.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwuK"
-      expect(transaction_2.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
-      expect(transaction_2.description).to eq "Transaction description"
-      expect(transaction_2.operation_date).to eq "2022-01-01T12:00:10Z"
-      expect(transaction_2.created_at).to eq "2022-01-01T12:00:00Z"
-      expect(transaction_2.valued_at).to eq "2022-01-01T12:00:10Z"
-      expect(transaction_2.operation_type).to eq "deposit"
-      expect(transaction_2.credit_debit).to eq "debit"
-      expect(transaction_2.amount).to be_a Devengo::Resources::Shared::Money
-      expect(transaction_2.amount.cents).to eq 100
-      expect(transaction_2.amount.currency).to eq "EUR"
-      expect(transaction_2.balance).to be_a Devengo::Resources::Shared::Money
-      expect(transaction_2.balance.cents).to eq 10_000
-      expect(transaction_2.balance.currency).to eq "EUR"
-      expect(transaction_2.company_reference).to eq "123"
-      expect(transaction_2.entity).to be_a Devengo::Resources::Transactions::Entity
-      expect(transaction_2.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
-      expect(transaction_2.entity.type).to eq "payment"
-      expect(transaction_2.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
-      expect(transaction_2.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
-      expect(transaction_2.third_party.name).to eq "Company S.L."
-      expect(transaction_2.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
-      expect(transaction_2.third_party.account.identifiers.count).to eq 1
-      expect(transaction_2.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::UkScan # rubocop:disable Layout/LineLength
-      expect(transaction_2.third_party.account.identifiers.first.type).to eq "ukscan"
-      expect(transaction_2.third_party.account.identifiers.first.sort_code).to eq "040342"
-      expect(transaction_2.third_party.account.identifiers.first.account_number).to eq "00631971"
-      expect(transaction_2.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
-      expect(transaction_2.third_party.account.bank.name).to eq "Revolut Payments UAB"
-      expect(transaction_2.third_party.account.bank.bic).to eq "REVOLT21"
+      expect(transaction2).to be_a Devengo::Resources::Transactions::Transaction
+      expect(instance_methods_count(transaction2)).to eq 13
+      expect(transaction2.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwuK"
+      expect(transaction2.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
+      expect(transaction2.description).to eq "Transaction description"
+      expect(transaction2.operation_date).to eq "2022-01-01T12:00:10Z"
+      expect(transaction2.created_at).to eq "2022-01-01T12:00:00Z"
+      expect(transaction2.valued_at).to eq "2022-01-01T12:00:10Z"
+      expect(transaction2.operation_type).to eq "deposit"
+      expect(transaction2.credit_debit).to eq "debit"
+      expect(transaction2.amount).to be_a Devengo::Resources::Shared::Money
+      expect(transaction2.amount.cents).to eq 100
+      expect(transaction2.amount.currency).to eq "EUR"
+      expect(transaction2.balance).to be_a Devengo::Resources::Shared::Money
+      expect(transaction2.balance.cents).to eq 10_000
+      expect(transaction2.balance.currency).to eq "EUR"
+      expect(transaction2.company_reference).to eq "123"
+      expect(transaction2.entity).to be_a Devengo::Resources::Transactions::Entity
+      expect(transaction2.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction2.entity.type).to eq "payment"
+      expect(transaction2.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction2.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
+      expect(transaction2.third_party.name).to eq "Company S.L."
+      expect(transaction2.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
+      expect(transaction2.third_party.account.identifiers.count).to eq 1
+      expect(transaction2.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::UkScan # rubocop:disable Layout/LineLength
+      expect(transaction2.third_party.account.identifiers.first.type).to eq "ukscan"
+      expect(transaction2.third_party.account.identifiers.first.sort_code).to eq "040342"
+      expect(transaction2.third_party.account.identifiers.first.account_number).to eq "00631971"
+      expect(transaction2.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
+      expect(transaction2.third_party.account.bank.name).to eq "Revolut Payments UAB"
+      expect(transaction2.third_party.account.bank.bic).to eq "REVOLT21"
     end
 
     it "return expected element" do

--- a/spec/devengo/api/transactions_service_spec.rb
+++ b/spec/devengo/api/transactions_service_spec.rb
@@ -3,7 +3,19 @@
 RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
   subject(:transactions_service) { described_class.new(initialize_client) }
 
-  shared_examples "transaction expects" do
+  describe "find transaction" do
+    include_context "with stub request",
+                    path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions/txn_3NuWZw8zSY2LNMoNXgVwaR",
+                    resource: "transactions/find"
+
+    let!(:transaction) do # rubocop:disable RSpec/LetSetup
+      transactions_service.find(account_id: "acc_fYpgX5Ytdxzexuf61lFmw", transaction_id: "txn_3NuWZw8zSY2LNMoNXgVwaR")
+    end
+
+    it_behaves_like "builds correct request",
+                    method: :get,
+                    path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions/txn_3NuWZw8zSY2LNMoNXgVwaR"
+
     it "transaction with expected data" do
       expect(transaction).to be_a Devengo::Resources::Transactions::Transaction
       expect(instance_methods_count(transaction)).to eq 13
@@ -39,39 +51,96 @@ RSpec.describe Devengo::API::TransactionsService, :integration, type: :api do
     end
   end
 
-  describe "find transaction" do
-    include_context "with stub request",
-                    path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions/txn_3NuWZw8zSY2LNMoNXgVwaR",
-                    resource: "transactions/find"
-
-    let!(:transaction) do # rubocop:disable RSpec/LetSetup
-      transactions_service.find(account_id: "acc_fYpgX5Ytdxzexuf61lFmw", transaction_id: "txn_3NuWZw8zSY2LNMoNXgVwaR")
-    end
-
-    it_behaves_like "builds correct request",
-                    method: :get,
-                    path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions/txn_3NuWZw8zSY2LNMoNXgVwaR"
-
-    it_behaves_like "transaction expects"
-  end
-
   describe "list transactions" do
     include_context "with stub request",
                     path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions",
                     resource: "transactions/list"
 
     let!(:transactions) { transactions_service.list(account_id: "acc_fYpgX5Ytdxzexuf61lFmw") }
-    let(:transaction) { transactions.first }
 
     it_behaves_like "builds correct request",
                     method: :get,
                     path: "accounts/acc_fYpgX5Ytdxzexuf61lFmw/transactions"
 
-    it_behaves_like "transaction expects"
+    it "transactions with expected data" do
+      transactions_array = []
+
+      transactions.each do |tr|
+        transactions_array.push tr
+      end
+
+      transaction_1 = transactions_array[0]
+      transaction_2 = transactions_array[1]
+
+      expect(transaction_1).to be_a Devengo::Resources::Transactions::Transaction
+      expect(instance_methods_count(transaction_1)).to eq 13
+      expect(transaction_1.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwaR"
+      expect(transaction_1.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
+      expect(transaction_1.description).to eq "Transaction description"
+      expect(transaction_1.operation_date).to eq "2022-01-01T12:00:10Z"
+      expect(transaction_1.created_at).to eq "2022-01-01T12:00:00Z"
+      expect(transaction_1.valued_at).to eq "2022-01-01T12:00:10Z"
+      expect(transaction_1.operation_type).to eq "deposit"
+      expect(transaction_1.credit_debit).to eq "debit"
+      expect(transaction_1.amount).to be_a Devengo::Resources::Shared::Money
+      expect(transaction_1.amount.cents).to eq 100
+      expect(transaction_1.amount.currency).to eq "EUR"
+      expect(transaction_1.balance).to be_a Devengo::Resources::Shared::Money
+      expect(transaction_1.balance.cents).to eq 10_000
+      expect(transaction_1.balance.currency).to eq "EUR"
+      expect(transaction_1.company_reference).to eq "123"
+      expect(transaction_1.entity).to be_a Devengo::Resources::Transactions::Entity
+      expect(transaction_1.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction_1.entity.type).to eq "payment"
+      expect(transaction_1.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction_1.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
+      expect(transaction_1.third_party.name).to eq "Company S.L."
+      expect(transaction_1.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
+      expect(transaction_1.third_party.account.identifiers.count).to eq 1
+      expect(transaction_1.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::Iban # rubocop:disable Layout/LineLength
+      expect(transaction_1.third_party.account.identifiers.first.type).to eq "iban"
+      expect(transaction_1.third_party.account.identifiers.first.iban).to eq "LT501243351241283711"
+      expect(transaction_1.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
+      expect(transaction_1.third_party.account.bank.name).to eq "Revolut Payments UAB"
+      expect(transaction_1.third_party.account.bank.bic).to eq "REVOLT21"
+
+      expect(transaction_2).to be_a Devengo::Resources::Transactions::Transaction
+      expect(instance_methods_count(transaction_2)).to eq 13
+      expect(transaction_2.id).to eq "txn_3NuWZw8zSY2LNMoNXgVwuK"
+      expect(transaction_2.account_id).to eq "acc_fYpgX5Ytdxzexuf61lFmw"
+      expect(transaction_2.description).to eq "Transaction description"
+      expect(transaction_2.operation_date).to eq "2022-01-01T12:00:10Z"
+      expect(transaction_2.created_at).to eq "2022-01-01T12:00:00Z"
+      expect(transaction_2.valued_at).to eq "2022-01-01T12:00:10Z"
+      expect(transaction_2.operation_type).to eq "deposit"
+      expect(transaction_2.credit_debit).to eq "debit"
+      expect(transaction_2.amount).to be_a Devengo::Resources::Shared::Money
+      expect(transaction_2.amount.cents).to eq 100
+      expect(transaction_2.amount.currency).to eq "EUR"
+      expect(transaction_2.balance).to be_a Devengo::Resources::Shared::Money
+      expect(transaction_2.balance.cents).to eq 10_000
+      expect(transaction_2.balance.currency).to eq "EUR"
+      expect(transaction_2.company_reference).to eq "123"
+      expect(transaction_2.entity).to be_a Devengo::Resources::Transactions::Entity
+      expect(transaction_2.entity.id).to eq "pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction_2.entity.type).to eq "payment"
+      expect(transaction_2.entity.ref).to eq "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
+      expect(transaction_2.third_party).to be_a Devengo::Resources::Shared::ThirdParties::ThirdParty
+      expect(transaction_2.third_party.name).to eq "Company S.L."
+      expect(transaction_2.third_party.account).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Account
+      expect(transaction_2.third_party.account.identifiers.count).to eq 1
+      expect(transaction_2.third_party.account.identifiers.first).to be_a Devengo::Resources::Shared::ThirdParties::Identifiers::UkScan # rubocop:disable Layout/LineLength
+      expect(transaction_2.third_party.account.identifiers.first.type).to eq "ukscan"
+      expect(transaction_2.third_party.account.identifiers.first.sort_code).to eq "040342"
+      expect(transaction_2.third_party.account.identifiers.first.account_number).to eq "00631971"
+      expect(transaction_2.third_party.account.bank).to be_a Devengo::Resources::Shared::ThirdParties::Accounts::Bank
+      expect(transaction_2.third_party.account.bank.name).to eq "Revolut Payments UAB"
+      expect(transaction_2.third_party.account.bank.bic).to eq "REVOLT21"
+    end
 
     it "return expected element" do
       expect(transactions).to be_a Devengo::Resources::Transactions::Collection
-      expect(transactions.count).to eq 1
+      expect(transactions.count).to eq 2
     end
   end
 end

--- a/spec/fixtures/responses/transactions/list/success.http
+++ b/spec/fixtures/responses/transactions/list/success.http
@@ -58,6 +58,46 @@ Via: 1.1 vegur
                     }
                 }
             }
+        },
+        {
+            "id": "txn_3NuWZw8zSY2LNMoNXgVwuK",
+            "account_id": "acc_fYpgX5Ytdxzexuf61lFmw",
+            "description": "Transaction description",
+            "operation_date": "2022-01-01T12:00:10Z",
+            "created_at": "2022-01-01T12:00:00Z",
+            "valued_at": "2022-01-01T12:00:10Z",
+            "operation_type": "deposit",
+            "credit_debit": "debit",
+            "amount": {
+                "cents": 100,
+                "currency": "EUR"
+            },
+            "company_reference": "123",
+            "entity": {
+                "id": "pyo_4JgnTOvdXQWn81NK1bOhIY",
+                "type": "payment",
+                "ref": "https://api.devengo.com/v1/payments/pyo_4JgnTOvdXQWn81NK1bOhIY"
+            },
+            "balance": {
+                "cents": 10000,
+                "currency": "EUR"
+            },
+            "third_party": {
+                "name": "Company S.L.",
+                "account": {
+                    "identifiers": [
+                        {
+                            "type": "ukscan",
+                            "sort_code": "040342",
+                            "account_number": "00631971"
+                        }
+                    ],
+                    "bank": {
+                        "name": "Revolut Payments UAB",
+                        "bic": "REVOLT21"
+                    }
+                }
+            }
         }
     ],
     "links": {
@@ -67,7 +107,7 @@ Via: 1.1 vegur
     },
     "meta": {
         "pagination": {
-            "total_items": 1
+            "total_items": 2
         }
     }
 }


### PR DESCRIPTION
There was a typo for "sort_code" ukscan identifiers. Added a test.