### PR TITLE
[DP-1856] Add account holders resource and service

### DIFF
--- a/lib/devengo/api/account_holders_service.rb
+++ b/lib/devengo/api/account_holders_service.rb
@@ -21,7 +21,10 @@ module Devengo
 
       def create(**opts)
         api_response = client.post(path: "account_holders", **opts)
-        Resources::AccountHolders::AccountHolder.from_raw(api_response: api_response, **api_response.body[:account_holder])
+        Resources::AccountHolders::AccountHolder.from_raw(
+          api_response: api_response,
+          **api_response.body[:account_holder]
+        )
       end
 
       def close(account_holder_id:, **opts)

--- a/lib/devengo/api/account_holders_service.rb
+++ b/lib/devengo/api/account_holders_service.rb
@@ -5,7 +5,7 @@ module Devengo
     class AccountHoldersService < Service
       def find(account_holder_id:, **opts)
         api_response = client.get(path: "account_holders/#{account_holder_id}", **opts)
-        Resources::AccountHolder.from_raw(
+        Resources::AccountHolders::AccountHolder.from_raw(
           api_response: api_response,
           **api_response.body[:account_holder]
         )

--- a/lib/devengo/api/account_holders_service.rb
+++ b/lib/devengo/api/account_holders_service.rb
@@ -5,7 +5,7 @@ module Devengo
     class AccountHoldersService < Service
       def find(account_holder_id:, **opts)
         api_response = client.get(path: "account_holders/#{account_holder_id}", **opts)
-        Resources::AccountHolders::AccountHolder.from_raw(
+        Resources::AccountHolder.from_raw(
           api_response: api_response,
           **api_response.body[:account_holder]
         )

--- a/lib/devengo/api/account_holders_service.rb
+++ b/lib/devengo/api/account_holders_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Devengo
+  module API
+    class AccountHoldersService < Service
+      def find(account_holder_id:, **opts)
+        api_response = client.get(path: "account_holders/#{account_holder_id}", **opts)
+        Resources::AccountHolders::AccountHolder.from_raw(
+          api_response: api_response,
+          **api_response.body[:account_holder]
+        )
+      end
+
+      def list(**opts)
+        api_response = client.get(path: "account_holders", **opts)
+        Resources::AccountHolders::Collection.from_raw(
+          api_response: api_response,
+          raw_collection: api_response.body[:account_holders]
+        )
+      end
+
+      def create(**opts)
+        api_response = client.post(path: "account_holders", **opts)
+        Resources::AccountHolders::AccountHolder.from_raw(api_response: api_response, **api_response.body[:account_holder])
+      end
+
+      def close(account_holder_id:, **opts)
+        client.patch(path: "account_holders/#{account_holder_id}/close", **opts)
+        nil
+      end
+    end
+  end
+end

--- a/lib/devengo/api/services.rb
+++ b/lib/devengo/api/services.rb
@@ -11,6 +11,10 @@ module Devengo
         @services[:accounts] ||= AccountsService.new(self)
       end
 
+      def account_holders
+        @services[:account_holders] ||= AccountHoldersService.new(self)
+      end
+
       def incoming_payments
         @services[:incoming_payments] ||= IncomingPaymentsService.new(self)
       end
@@ -40,6 +44,7 @@ end
 
 require_relative "service"
 
+require_relative "account_holders_service"
 require_relative "accounts_service"
 require_relative "auth_service"
 require_relative "incoming_payments_service"

--- a/lib/devengo/resources/account_holders/account_holder.rb
+++ b/lib/devengo/resources/account_holders/account_holder.rb
@@ -6,10 +6,13 @@ module Devengo
       class AccountHolder < Shared::BaseResponse
         map :id
         map :commercial_name
+        map :legal_name
+        map :taxid
+        map :status
         map :company_reference
+        map :slug
+        map :curreny
         map :metadata
-        map :created_at
-        map :closed_at
 
         def self.from_raw(api_response:, **attributes)
           super api_response: api_response, **attributes

--- a/lib/devengo/resources/account_holders/account_holder.rb
+++ b/lib/devengo/resources/account_holders/account_holder.rb
@@ -13,7 +13,7 @@ module Devengo
         map :closed_at
         map :company_reference
         map :slug
-        map :curreny
+        map :currency
         map :metadata
 
         def self.from_raw(api_response:, **attributes)

--- a/lib/devengo/resources/account_holders/account_holder.rb
+++ b/lib/devengo/resources/account_holders/account_holder.rb
@@ -9,6 +9,8 @@ module Devengo
         map :legal_name
         map :taxid
         map :status
+        map :created_at
+        map :closed_at
         map :company_reference
         map :slug
         map :curreny

--- a/lib/devengo/resources/account_holders/account_holder.rb
+++ b/lib/devengo/resources/account_holders/account_holder.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Devengo
+  module Resources
+    module AccountHolders
+      class AccountHolder < Shared::BaseResponse
+        map :id
+        map :commercial_name
+        map :company_reference
+        map :metadata
+        map :created_at
+        map :closed_at
+
+        def self.from_raw(api_response:, **attributes)
+          super api_response: api_response, **attributes
+        end
+      end
+    end
+  end
+end

--- a/lib/devengo/resources/account_holders/collection.rb
+++ b/lib/devengo/resources/account_holders/collection.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Devengo
+  module Resources
+    module AccountHolders
+      class Collection < Shared::BaseResponseCollection
+        def self.item_klass
+          AccountHolder
+        end
+      end
+    end
+  end
+end

--- a/lib/devengo/resources/accounts/account.rb
+++ b/lib/devengo/resources/accounts/account.rb
@@ -5,6 +5,7 @@ module Devengo
     module Accounts
       class Account < Shared::BaseResponse
         map :id
+        map :account_holder_id
         map :bank
         map :status
         map :name

--- a/lib/devengo/resources/shared/base.rb
+++ b/lib/devengo/resources/shared/base.rb
@@ -38,6 +38,8 @@ require_relative "base_collection"
 require_relative "base_response"
 require_relative "base_response_collection"
 
+require_relative "../account_holders/account_holder"
+require_relative "../account_holders/collection"
 require_relative "../accounts/account"
 require_relative "../accounts/balance"
 require_relative "../accounts/collection"

--- a/spec/devengo/api/account_holders_service_spec.rb
+++ b/spec/devengo/api/account_holders_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe Devengo::API::AccountHoldersService, :integration, type: :api do
+  subject(:account_holders_service) { described_class.new(initialize_client) }
+
+  shared_examples "account holders expects" do |parameters|
+    it "account holder with expected data" do
+      expect(account_holder).to be_a Devengo::Resources::AccountHolders::AccountHolder
+      expect(instance_methods_count(account_holder)).to eq 11
+      expect(account_holder.id).to eq "ach_5hAMRnqljBGXuvhfz0uRip"
+      expect(account_holder.status).to eq "created"
+      expect(account_holder.commercial_name).to eq "My account holder"
+      expect(account_holder.legal_name).to eq "My account holder SL"
+      expect(account_holder.currency).to eq "EUR"
+      expect(account_holder.metadata).to eq parameters[:metadata]
+      expect(account_holder.created_at).to eq "2023-01-01T12:00:00Z"
+      expect(account_holder.closed_at).to be_nil
+    end
+  end
+
+  describe "find account holder" do
+    include_context "with stub request",
+                    path: "account_holders/ach_5hAMRnqljBGXuvhfz0uRip",
+                    resource: "account_holders/find"
+
+    let!(:account_holder) { account_holders_service.find(account_holder_id: "ach_5hAMRnqljBGXuvhfz0uRip") } # rubocop:disable RSpec/LetSetup
+
+    it_behaves_like "builds correct request",
+                    path: "account_holders/ach_5hAMRnqljBGXuvhfz0uRip"
+
+    it_behaves_like "account holders expects",
+                    metadata: { example_key: "example_value" }
+  end
+
+  describe "list account holders" do
+    include_context "with stub request",
+                    path: "account_holders",
+                    resource: "account_holders/list"
+
+    let!(:account_holders) { account_holders_service.list }
+    let(:account_holder) { account_holders.first }
+
+    it_behaves_like "builds correct request",
+                    path: "account_holders"
+
+    it_behaves_like "account holders expects",
+                    metadata: { example_key: "example_value" }
+
+    it "return expected element" do
+      expect(account_holders).to be_a Devengo::Resources::AccountHolders::Collection
+      expect(account_holders.count).to eq 2
+    end
+  end
+
+  describe "create account holder" do
+    include_context "with stub request",
+                    method: :post,
+                    path: "account_holders",
+                    resource: "account_holders/create"
+
+    let!(:account_holder) do # rubocop:disable RSpec/LetSetup
+      account_holders_service.create(
+        commercial_name: "My new account holder",
+        legal_name: "My new account holder SL",
+        currency: "EUR",
+        metadata: { example_key: "example_value" }
+      )
+    end
+
+    it_behaves_like "builds correct request",
+                    method: :post,
+                    path: "account_holder",
+                    body: {
+                      commercial_name: "My new account holder",
+                      legal_name: "My new account holder SL",
+                      currency: "EUR",
+                      metadata: { example_key: "example_value" },
+                    }
+
+    it_behaves_like "account holders expects",
+                    metadata: { example_key: "example_value" }
+  end
+
+  describe "close account holder" do
+    include_context "with stub request",
+                    method: :patch,
+                    path: "account_holders/ach_5hAMRnqljBGXuvhfz0uRip/close",
+                    resource: "account_holders/close"
+
+    let!(:response) { account_holders_service.close(account_holder_id: "ach_5hAMRnqljBGXuvhfz0uRip") }
+
+    it_behaves_like "builds correct request",
+                    method: :patch,
+                    path: "account_holders/ach_5hAMRnqljBGXuvhfz0uRip/close"
+
+    it "return nil" do
+      expect(response).to be_nil
+    end
+  end
+end

--- a/spec/devengo/api/accounts_service_spec.rb
+++ b/spec/devengo/api/accounts_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Devengo::API::AccountsService, :integration, type: :api do
   shared_examples "accounts expects" do |parameters|
     it "account with expected data" do
       expect(account).to be_a Devengo::Resources::Accounts::Account
-      expect(instance_methods_count(account)).to eq 10
+      expect(instance_methods_count(account)).to eq 11
       expect(account.id).to eq "acc_7SZwPFdReAtDu8aNr1T5dE"
       expect(account.status).to eq "created"
       expect(account.name).to eq "My account"

--- a/spec/devengo/api/services_spec.rb
+++ b/spec/devengo/api/services_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Devengo::API::Services, :unit, type: :api do
   let!(:client) { initialize_client }
 
   it "includes all expected services" do
-    expect(instance_methods_count(described_class)).to eq 8
+    expect(instance_methods_count(described_class)).to eq 9
     expect(client.accounts).to be_an_instance_of(Devengo::API::AccountsService)
     expect(client.incoming_payments).to be_an_instance_of(Devengo::API::IncomingPaymentsService)
     expect(client.auth).to be_an_instance_of(Devengo::API::AuthService)

--- a/spec/fixtures/responses/account_holders/close/success.http
+++ b/spec/fixtures/responses/account_holders/close/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 204 No Content
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: application/json; charset=utf-8
+X-RateLimit-Limit: 1500
+X-RateLimit-Remaining: 1499
+X-RateLimit-Reset: 1676233020
+ETag: W/"7683438fa208a99834e0f22323efbbe9"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: c1f2cabd-ea2d-46c7-9adc-239802f7f757
+X-Runtime: 0.261720
+Vary: Origin

--- a/spec/fixtures/responses/account_holders/create/success.http
+++ b/spec/fixtures/responses/account_holders/create/success.http
@@ -1,0 +1,31 @@
+HTTP/1.1 201 Created
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: application/json; charset=utf-8
+X-RateLimit-Limit: 1500
+X-RateLimit-Remaining: 1499
+X-RateLimit-Reset: 1676233020
+ETag: W/"7683438fa208a99834e0f22323efbbe9"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: c1f2cabd-ea2d-46c7-9adc-239802f7f757
+X-Runtime: 0.261720
+Vary: Origin
+
+{
+    "account_holder": {
+        "id": "ach_5hAMRnqljBGXuvhfz0uRip",
+        "status": "created",
+        "created_at": "2023-01-01T12:00:00Z",
+        "commercial_name": "My account holder",
+        "legal_name": "My account holder SL",
+        "currency": "EUR",
+        "metadata": {
+            "example_key": "example_value"
+        },
+        "closed_at": null
+    }
+}

--- a/spec/fixtures/responses/account_holders/find/success.http
+++ b/spec/fixtures/responses/account_holders/find/success.http
@@ -1,0 +1,34 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: application/json; charset=utf-8
+X-Ratelimit-Limit: 1500
+X-Ratelimit-Remaining: 1499
+X-Ratelimit-Reset: 1675958040
+Etag: W/"3c456a85e68cc323b63ffb8790cfb4ce"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 1eb854ab-48e9-4ebe-92a9-9647b663b333
+X-Runtime: 0.032480
+Strict-Transport-Security: max-age=63072000; includeSubDomains
+Vary: Origin
+Via: 1.1 vegur
+
+{
+    "account_holder": {
+        "id": "ach_5hAMRnqljBGXuvhfz0uRip",
+        "status": "created",
+        "created_at": "2023-01-01T12:00:00Z",
+        "commercial_name": "My account holder",
+        "legal_name": "My account holder SL",
+        "currency": "EUR",
+        "metadata": {
+            "example_key": "example_value"
+        },
+        "closed_at": null
+    }
+}

--- a/spec/fixtures/responses/account_holders/list/success.http
+++ b/spec/fixtures/responses/account_holders/list/success.http
@@ -1,0 +1,56 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: application/json; charset=utf-8
+X-Ratelimit-Limit: 1500
+X-Ratelimit-Remaining: 1499
+X-Ratelimit-Reset: 1675957920
+Etag: W/"4c95a420ffa0bfdf75d3cedd3ee131f1"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 930d21a6-fd00-4b89-a81e-66d2763faa40
+X-Runtime: 0.109951
+Strict-Transport-Security: max-age=63072000; includeSubDomains
+Vary: Origin
+Via: 1.1 vegur
+
+{
+    "account_holders": [
+        {
+            "id": "ach_5hAMRnqljBGXuvhfz0uRip",
+            "status": "created",
+            "created_at": "2023-01-01T12:00:00Z",
+            "commercial_name": "My account holder",
+            "legal_name": "My account holder SL",
+            "currency": "EUR",
+            "metadata": {
+                "example_key": "example_value"
+            },
+            "closed_at": null
+        },
+        {
+            "id": "ach_6hAMRnqljAFXuvhfz0uSac",
+            "status": "closed",
+            "created_at": "2023-02-01T12:00:00Z",
+            "commercial_name": "My account holder 2",
+            "legal_name": "My account holder 2 SL",
+            "currency": "EUR",
+            "metadata": {},
+            "closed_at": "2023-02-15T12:00:00Z"
+        }
+    ],
+    "links": {
+        "self": "https://api.sandbox.devengo.com/v1/account_holders?page=1&page_size=100",
+        "first": "https://api.sandbox.devengo.com/v1/account_holders?page=1&page_size=100",
+        "last": "https://api.sandbox.devengo.com/v1/account_holders?page=1&page_size=100"
+    },
+    "meta": {
+        "pagination": {
+            "total_items": 2
+        }
+    }
+}


### PR DESCRIPTION
[DP-1856]

Add account holder resource and service. 

⚠️ NOTE: A curious situation arises here, and that is that if we merge this to master we will make the account holder functionality "public" when we haven't even announced it yet and it is under feature flag in the API. I suppose we could treat this branch as an "experimental" feature and make the Devengo Control Panel use it, but I don't think it's necessary (it's more of a thought exercise).

[DP-1856]: https://devengers.atlassian.net/browse/DP-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ