### PR TITLE
Accept nil for transaction balance field

### DIFF
--- a/lib/devengo/resources/transactions/transaction.rb
+++ b/lib/devengo/resources/transactions/transaction.rb
@@ -22,7 +22,7 @@ module Devengo
           super api_response: api_response,
                 **attributes,
                 third_party: Shared::ThirdParties::ThirdParty.from_raw(**attributes[:third_party]),
-                balance: Shared::Money.from_raw(**attributes[:balance]),
+                balance: Shared::Money.from_raw_nullable(**attributes[:balance]),
                 amount: Shared::Money.from_raw(**attributes[:amount]),
                 entity: Entity.from_raw_nullable(attributes[:entity])
         end

--- a/lib/devengo/resources/transactions/transaction.rb
+++ b/lib/devengo/resources/transactions/transaction.rb
@@ -22,7 +22,7 @@ module Devengo
           super api_response: api_response,
                 **attributes,
                 third_party: Shared::ThirdParties::ThirdParty.from_raw(**attributes[:third_party]),
-                balance: Shared::Money.from_raw_nullable(**attributes[:balance]),
+                balance: Shared::Money.from_raw_nullable(attributes[:balance]),
                 amount: Shared::Money.from_raw(**attributes[:amount]),
                 entity: Entity.from_raw_nullable(attributes[:entity])
         end


### PR DESCRIPTION
[DP-2179]

Alternative approach to: https://github.com/devengoapp/web-controlpanel/pull/1449

A possible disadvantage of this is that we would be accepting nil values even though it should not be possible to receive them (for example, with the changes introduced that will prevent transactions from being filtered from the API).

[DP-2179]: https://devengers.atlassian.net/browse/DP-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ